### PR TITLE
fix: Publish only necessary files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "webpack-cli": "3.3.6",
     "webpack-node-externals": "1.7.2"
   },
+  "files": [
+    "dist",
+    "websql.d.ts"
+  ],
   "homepage": "http://github.com/wireapp/websql",
   "husky": {
     "hooks": {


### PR DESCRIPTION
Before:
```
.
├── dist
│   ├── websql.js
│   ├── websql-worker-debug.js
│   └── websql-worker.js
├── exports
│   ├── functions.json
│   └── runtime_methods.json
├── LICENSE
├── Makefile
├── package.json
├── packages
│   ├── worker
│   │   ├── src
│   │   │   ├── DatabaseInteface.ts
│   │   │   ├── Database.ts
│   │   │   ├── global.d.ts
│   │   │   ├── Helper.ts
│   │   │   ├── index.ts
│   │   │   ├── lib
│   │   │   │   └── sqlite3.ts
│   │   │   ├── MessageHandler.ts
│   │   │   ├── MessageQueue.ts
│   │   │   ├── StatementInterface.ts
│   │   │   └── Statement.ts
│   │   ├── tsconfig.json
│   │   └── webpack.config.js
│   └── wrapper
│       ├── src
│       │   ├── global.d.ts
│       │   ├── Helper.ts
│       │   ├── index.ts
│       │   └── WorkerInterface.ts
│       ├── tsconfig.json
│       └── webpack.config.js
├── README.md
├── sqlite
│   └── extension-functions.c
├── tsconfig.json
├── tslint.json
└── websql.d.ts

9 directories, 31 files
```

After:
```
.
├── dist
│   ├── websql.js
│   ├── websql-worker-debug.js
│   └── websql-worker.js
├── LICENSE
├── package.json
├── README.md
└── websql.d.ts

1 directory, 7 files
```